### PR TITLE
Added rejection algorithm similar to IRAF's ccdreject

### DIFF
--- a/pro/flame_combine.pro
+++ b/pro/flame_combine.pro
@@ -64,11 +64,8 @@ PRO flame_combine_stack, fuel=fuel, filenames=filenames, sky_filenames=sky_filen
 	exptime_cube = dblarr( N_frames, N_x, N_y )
 	exptime_cube[*] = !values.d_nan
 
-
 	; read in all frames
 	; ----------------------------------------------------------------------------
-
-	; read in all frames
 	for i_frame=0, N_frames-1 do begin
 
 		; read in image and header
@@ -120,19 +117,42 @@ PRO flame_combine_stack, fuel=fuel, filenames=filenames, sky_filenames=sky_filen
 			if sky_filenames[i_frame] NE '' then begin
 				sky = mrdfits(sky_filenames[i_frame], 0, /silent)
 				sky_cube[i_frame, *, bot_ref:top_ref] = sky[*, bot_i:top_i]
-			endif
+		endif
 
-  	; find the exposure time: try EXPTIME first, then TRUITIME
-	  exptime = fxpar(header, 'EXPTIME', missing=-1.0)
-	  if exptime EQ -1.0 then exptime = fxpar(header, 'TRUITIME', missing=-1.0)
+		; find the exposure time: try EXPTIME first, then TRUITIME
+		exptime = fxpar(header, 'EXPTIME', missing=-1.0)
+		if exptime EQ -1.0 then exptime = fxpar(header, 'TRUITIME', missing=-1.0)
 
 		; make map of exposure time
 		map_exptime = im*0.0 + exptime ; account for NaNs
 		exptime_cube[i_frame, *, bot_ref:top_ref] = map_exptime[*, bot_i:top_i]
 
-
 	endfor
 
+	; ccdreject -- iterative rejection based on ccd noise parameters ;
+	; based on ccdreject algorithm of IRAF, using the median and assuming the
+	; sensitivity noise of the detector is zero. The values in
+	; settings.combine_ccdreject_sigma are equivalent to lsigma and hsigma.
+	; ----------------------------------------------------------------------------
+	if fuel.settings.combine_ccdreject then begin
+		; iterate up to Nframes-2 times (so that at least two frames remain)
+		; each iteration can mask pixels in im_cube, which are ignored by
+		; median()
+		for i_iter=0, N_frames-2 do begin
+			; get median at each pixel in electrons
+			median_im_e = median(im_cube*exptime_cube, dimension=1)
+			median_cube_e = im_cube
+			for i_frame=0,N_frames-1 do median_cube_e[i_frame, *, *] = median_im_e
+			; get noise level for each pixel in electrons (readnoise + poisson)
+			ccdnoise_cube_e = sqrt(fuel.instrument.readnoise^2 + median_cube_e)
+			deviation = (im_cube*exptime_cube - median_cube_e)/ccdnoise_cube_e
+			; mask values larger than the upper ccdreject limit
+			im_cube[where(deviation GT fuel.settings.combine_ccdreject_sigma[1], /null)] = !values.d_nan
+			; mask values smaller than the lower ccdreject limit
+			im_cube[where(-deviation GT fuel.settings.combine_ccdreject_sigma[0], /null)] = !values.d_nan
+
+		endfor
+	endif
 
 	; sigma-clipping
 	; ----------------------------------------------------------------------------

--- a/pro/flame_util_create_fuel.pro
+++ b/pro/flame_util_create_fuel.pro
@@ -204,6 +204,8 @@ FUNCTION flame_util_create_fuel, input
     skysub_reject_window: 2.0, $
     interpolation_method: 'NaturalNeighbor', $
     frame_weights: 'None', $
+    combine_ccdreject : 0, $
+    combine_ccdreject_sigma : [3., 3.], $
     combine_sigma_clip : 2.0, $
     combine_min_framefrac : combine_min_framefrac, $
     extract_optimal : 1, $


### PR DESCRIPTION
Can be used by setting settings.combine_ccdreject = 1, and is controlled
by settings.combine_ccdreject_sigma (default [3., 3.]), which contains
the lower and upper sigma values, respectively, for rejection.

If enabled (it is off by default), ccdreject is run during the combine
phase immediately prior to sigma clipping.  If the CCD parameters
(readnoise and gain) are known, there is probably no reason to perform
additional sigma clipping.

May resolve #9; in my case it certainly did.